### PR TITLE
Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://github.com/sigmavirus24/betamax
 
 Package license: Apache
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: A VCR imitation for python-requests
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.1" %}
+{% set version = "0.6.0" %}
 
 package:
     name: betamax
@@ -7,7 +7,7 @@ package:
 source:
     fn: betamax-{{ version }}.tar.gz
     url: https://pypi.python.org/packages/source/b/betamax/betamax-{{ version }}.tar.gz
-    md5: 349e69e1a9da664a8ab8c0f545e2e38f
+    md5: f70c210d760f5962c03d83eca4ec18ea
 
 build:
     number: 0


### PR DESCRIPTION
### History
- Add betamax_recorder pytest fixture
- Change default behaviour to allow duplicate interactions to be recorded in single cassette
- Add allow_playback_repeats to allow an interaction to be used more than once from a single cassette
- Always return a new Response object from an Interaction to allow for a streaming response to be usable multiple times
- Remove CI support for Pythons 2.6 and 3.2
