### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.0" %}
+{% set version = "0.7.0" %}
 
 package:
     name: betamax
@@ -6,8 +6,8 @@ package:
 
 source:
     fn: betamax-{{ version }}.tar.gz
-    url: https://pypi.python.org/packages/source/b/betamax/betamax-{{ version }}.tar.gz
-    md5: f70c210d760f5962c03d83eca4ec18ea
+    url: https://pypi.io/packages/source/b/betamax/betamax-{{ version }}.tar.gz
+    md5: ddb657a6e546c1aeec403b499f31ff44
 
 build:
     number: 0


### PR DESCRIPTION
# History
## 0.7.0 - 2016-04-29
- Add `before_record` and `before_playback` hooks
- Allow per-cassette placeholders to be merged and override global
  placeholders
- Fix bug where the `QueryMatcher` failed matching on high Unicode points
