### PR TITLE
Update to 0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About betamax
 
 Home: https://github.com/sigmavirus24/betamax
 
-Package license: Apache
+Package license: Apache-2.0
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.0" %}
+{% set version = "0.7.1" %}
 
 package:
     name: betamax
@@ -6,8 +6,8 @@ package:
 
 source:
     fn: betamax-{{ version }}.tar.gz
-    url: https://pypi.io/packages/source/b/betamax/betamax-{{ version }}.tar.gz
-    md5: ddb657a6e546c1aeec403b499f31ff44
+    url: https://github.com/sigmavirus24/betamax/archive/{{ version }}.tar.gz
+    sha256: a128d61905a2e50bd6f2a38b9154ed0e4111f50a156bc25faec61b077f748fdf
 
 build:
     number: 0
@@ -30,7 +30,7 @@ test:
 
 about:
     home: https://github.com/sigmavirus24/betamax
-    license: Apache
+    license: Apache-2.0
     summary: A VCR imitation for python-requests
 
 extra:


### PR DESCRIPTION
## 0.7.1 - 2016-06-14
- Fix issue #108 by effectively copying the items in the match_requests_on
  list into the match_options set on a Cassette instance
