### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yaml and/or the recipe/meta.yaml.
 
-language: objective-c
+language: generic
+
+os: osx
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/betamax-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/betamax-feedstock)
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/betamax-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/betamax-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/betamax-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/betamax-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/betamax-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/betamax-feedstock/branch/master)
 
@@ -83,12 +83,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/betamax/ba
 Updating betamax-feedstock
 ==========================
 
-If you would like to improve the betamax recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the betamax recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/betamax-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.2" %}
+{% set version = "0.8.0" %}
 
 package:
     name: betamax
@@ -7,7 +7,7 @@ package:
 source:
     fn: betamax-{{ version }}.tar.gz
     url: https://github.com/sigmavirus24/betamax/archive/{{ version }}.tar.gz
-    sha256: 3f00bd14fcdad085c16c8c483a367267ef8b94dacc1f905a206c5ad1741800ca
+    sha256: 2304f2c772c111425592fd325fe26c3f23afdea0e8a286d6be23bfcb71fc35e2
 
 build:
     number: 0


### PR DESCRIPTION
```
History
=======

0.8.0 - 2016-08-16
------------------

- Add ``betamax_parametrized_recorder`` and ``betamax_parametrized_session``
  to our list of pytest fixtures so that users will have parametrized cassette
  names when writing parametrized tests with our fixtures. (I wonder if I can
  mention parametrization a bunch more times so I can say parametrize a lot in
  this bullet note.)
- Add ``ValidationError`` and a set of subclasses for each possible validation
  error.
- Raise ``InvalidOption`` on unknown cassette options rather than silently
  ignoring extra options.
- Raise a subclass of ``ValidationError`` when a particular cassette option is
  invalid, rather than silently ignoring the validation failure.
```
